### PR TITLE
Added Raspberry-Pi armv8 support

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,33 @@
+name: Build docker image CI
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64/v8
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/tor-hiddenservice-nginx:latest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Feel free to open issues on this project if you see something wrong.
 
 Easily run a hidden service inside the Tor network with this container
 
-
 Generate the skeleton configuration for you hidden service, replace <pattern>
 for your hidden service pattern name. Example, if you want to your hidden
 service contain the word 'boss', just use this word as argument. Be aware that 
@@ -23,7 +22,6 @@ bigger the pattern, more time it will take to generate it.
 ```sh
 docker run -it --rm -v $(pwd)/web:/web ozeliurs/tor-hiddenservice-nginx generate <pattern>
 ```
-
 
 Create an container named 'hiddensite' to serve your generated hidden service
 
@@ -71,59 +69,13 @@ And you have the service running ! :)
    
 # FAQ
 
-## Anti-Pattern
-
-While is not a good thing to run everything in one container, this is a easy way
-to get started if you don't have that much experience with docker and hidden
-services. If you want to use something more elaborated, check this
-[repository](https://github.com/opsxcq/docker-tor).
-
-Here is an example of how a deploy using this other image looks like.
-
-```yml
-version: '3'
-
-services:
-  tor:
-    image: strm/tor
-    restart: always
-    depends_on:
-      - backend
-    environment:
-        LISTEN_PORT: "80"
-        REDIRECT: "backend:80"
-        PRIVATE_KEY: |
-          -----BEGIN RSA PRIVATE KEY-----
-          MIICXQIBAAKBgQDSqBzjGxL+UFdrFJSdc+LJn3RrXiaZ7k6kgSw8KqOCSRgIr2qO
-          XZrCa3YHE+PqsfbDVF0GO0Xy3A9fsIxRFMUo3K++3BaVJslUbqK2TH9fJt5Ji1b6
-          N5UzXsEzf73atXwMF63hgVFZFLhfSWH8jGE1svwDXn0YQWP88PVX34SrWQIDASsd
-          AoGAUWdd+/m9TrTQyqK0IbzIr0fYQ5gDq4mv1GLEYjR4SWF8pSCxL1yOBsmQ02sj
-          BSS2Vw4dpFfloCrRw2ipM8ac4kdLGCoYefQHwW2Kfdf9raVfPDP7vcxrs37sOgOh
-          2rSXCOOrmcoMrEka2/OTGW15jaNUEEoWacS3YL1Fj0Bi6g0CQQD4ZmBiF6qu2XnT
-          8lMr1Asdz3K8fYiyfl6CzHItUubAbQ8ipv12q8CerJqk3dO98V+w8llAsQ7BT5wq
-          8AZOPQR3AkEA2RobnACDvb2Jw+dYSFsqrHyIDojKsrNiDEFedkiFijRFqme+nrif
-          kJ4yTnSiphC+rSSBbvYMawsqiWBA7UPSrwJBAKXSVQClxNUpJ2PZt91HZAtuipRt
-          t8suGIY4mot1iDRN0XdiNN8TNZ3qLag7wUU4or+Yn/3Xae1euHpyftTxmYsCQQCd
-          oJxsGotYx62ULxPqz0um7yEWOU6hUAy8MB3X3FcTCjGO0PPKpfJ2ntXo0Ajcp5ci
-          msi81/e9DTnF9mPjtsY9AkAUG6heBlETMFzyka9FHPgu9aN2kRwvJ3QZDHuPxYG4
-          VZwljLxstlx57+N74D0aj6wrJw+iBH2BI+b+ZpnLXyy7
-          -----END RSA PRIVATE KEY-----
-```
-
-To make it work you should also add a webserver with the name `backend`, and add
-your content there. There are more moving pieces using a deploy like this, so
-this is the justification for this repository, for people who never put anything
-on the deep web being able to enjoy it without busting their asses debugging
-some infrastructure.
-
-
-## Build
+## Build Docker image
 
 ```
 docker build -t ozeliurs/tor-hiddenservice-nginx .
 ```
 
-## Run
+## Run Docker container
 
 ```
 docker run -d --restart=always --name hiddensite -v $(pwd)/web:/web ozeliurs/tor-hiddenservice-nginx 
@@ -133,5 +85,4 @@ docker run -d --restart=always --name hiddensite -v $(pwd)/web:/web ozeliurs/tor
 
 ```
 docker run -it --rm -v $(pwd)/web:/web --entrypoint /bin/bash ozeliurs/tor-hiddenservice-nginx
-
 ```


### PR DESCRIPTION
Hey Maxime, I've added support for raspberry pi using ARMv8 processors:

- RPi 2 Model B v1.2
- RPi 3 Model A+
- RPi 3 Model B
- RPi 3 Model B+
- RPi 4 Model B
- RPi Zero 2 W

The docker image is created automatically with GitHub Actions. Please add your `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to your repo action secrets and it will create and push the docker images to DockerHub.

You can check an example here: [https://hub.docker.com/r/danielpcostas/tor-hiddenservice-nginx/tags](https://hub.docker.com/r/danielpcostas/tor-hiddenservice-nginx/tags)

Also check the action run here: [https://github.com/danielcharrua/docker-tor-hiddenservice-nginx/actions](https://github.com/danielcharrua/docker-tor-hiddenservice-nginx/actions)

When you run `docker pull` command, it will resolve the host you are using and pull the right image.

Also deleted some old example from the readme file that was using v2 onion addresses (now deprecated).

In a future PR I will add to the readme the workflow to build the docker image locally with [buildx as explained here](https://docs.docker.com/build/building/multi-platform/).